### PR TITLE
Improve MySQL table quoting

### DIFF
--- a/src/transqlate/schema_pipeline/extractor.py
+++ b/src/transqlate/schema_pipeline/extractor.py
@@ -236,9 +236,14 @@ class MySQLSchemaExtractor(BaseSchemaExtractor):
         rows = self._safe_exec("SHOW TABLES")
         return [r[0] for r in rows]
 
+    @staticmethod
+    def _quote_identifier(identifier: str) -> str:
+        """Return a backtick quoted identifier safe for MySQL."""
+        return f"`{identifier.replace('`', '``')}`"
+
     def get_columns(self, table):
-        tbl = table.replace("`", "``")  # quote identifier for safety
-        rows = self._safe_exec(f"DESCRIBE `{tbl}`")
+        quoted_tbl = self._quote_identifier(table)
+        rows = self._safe_exec(f"DESCRIBE {quoted_tbl}")
         return [{"name": r[0], "type": _bytes2str(r[1]),
                  "pk": (r[3] == "PRI")} for r in rows]
 


### PR DESCRIPTION
## Summary
- wrap MySQL table names with a quoting helper so unusual identifiers work

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ad24962f08333ab429876a90a9d20