### PR TITLE
Add CLI max_new_tokens option

### DIFF
--- a/src/transqlate/inference.py
+++ b/src/transqlate/inference.py
@@ -25,7 +25,7 @@ PROMPT_TEMPLATE = (
 )  # <- identical to fine-tune dataset (PUT_QUESTION_IN_INSTRUCTION=True)
 
 _DEFAULT_GEN_KWARGS = dict(
-    max_new_tokens=512,
+    max_new_tokens=2048,
     temperature=0.1,
     top_p=0.9,
     do_sample=True,


### PR DESCRIPTION
## Summary
- increase default generation limit to 2048 tokens
- add `--max-new-tokens` CLI argument with validation
- plumb max token limit through REPL and one-shot modes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b2d4a0bfc83339ef5e8dce47dbd93