### PR TITLE
Add connection troubleshooting support

### DIFF
--- a/tests/test_troubleshoot.py
+++ b/tests/test_troubleshoot.py
@@ -1,0 +1,50 @@
+import sys
+import types
+import importlib
+from pathlib import Path
+
+
+def load_troubleshoot_dict():
+    stub_names = {
+        "rich": types.ModuleType("rich"),
+        "rich.console": types.ModuleType("rich.console"),
+        "rich.panel": types.ModuleType("rich.panel"),
+        "rich.prompt": types.ModuleType("rich.prompt"),
+        "rich.table": types.ModuleType("rich.table"),
+        "transqlate.schema_pipeline.extractor": types.ModuleType("dummy"),
+        "transqlate.schema_pipeline.formatter": types.ModuleType("dummy"),
+        "transqlate.schema_pipeline.orchestrator": types.ModuleType("dummy"),
+        "transqlate.schema_pipeline.selector": types.ModuleType("dummy"),
+        "transqlate.inference": types.ModuleType("dummy"),
+        "transformers": types.ModuleType("dummy"),
+    }
+    stub_names["rich.console"].Console = object
+    stub_names["rich.panel"].Panel = object
+    stub_names["rich.prompt"].Prompt = object
+    stub_names["rich.table"].Table = object
+    stub_names["transqlate.schema_pipeline.extractor"].get_schema_extractor = lambda *a, **k: None
+    stub_names["transqlate.schema_pipeline.formatter"].format_schema = lambda *a, **k: ""
+    stub_names["transqlate.schema_pipeline.orchestrator"].SchemaRAGOrchestrator = object
+    stub_names["transqlate.schema_pipeline.selector"].build_table_embeddings = lambda *a, **k: None
+    stub_names["transqlate.inference"].NL2SQLInference = object
+    stub_names["transformers"].AutoTokenizer = object
+
+    saved = {name: sys.modules.get(name) for name in stub_names}
+    sys.modules.update(stub_names)
+    sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+    try:
+        cli = importlib.import_module("transqlate.cli.cli")
+    finally:
+        for name, mod in saved.items():
+            if mod is None:
+                del sys.modules[name]
+            else:
+                sys.modules[name] = mod
+    return cli._DB_TROUBLESHOOT
+
+_DB_TROUBLESHOOT = load_troubleshoot_dict()
+
+
+def test_mssql_troubleshoot_text():
+    text = _DB_TROUBLESHOOT.get("mssql", "")
+    assert "SQL Server Authentication" in text


### PR DESCRIPTION
## Summary
- include MSSQL troubleshooting steps
- expose `:troubleshoot` command while entering DB params and after failed connects
- test the troubleshooting dictionary

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c2a91f85883338228ea0cd689e974