### PR TITLE
Add multi-engine schema qualification

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,28 @@ transqlate -q "Which customers made purchases in March?" --db-path path/to/your.
 * Safe execution with confirmation for data-altering queries
 * Dynamic schema exploration (`:show schema`)
 * Automatic SQL dialect fixes for Postgres, MySQL, SQL Server and Oracle
+* Automatic schema qualification for SQL Server, Oracle and PostgreSQL when tables live outside their default schemas
 * Command history, example prompts, and connection switching
+
+#### Schema Qualification Examples
+
+```
+-- Before (fails on SQL Server)
+SELECT TOP 5 Product FROM Products;
+
+-- After (works)
+SELECT TOP 5 Product FROM Sales.Products;
+
+-- PostgreSQL example
+SELECT * FROM users JOIN orders ON users.id=orders.user_id;
+-- becomes
+SELECT * FROM auth.users JOIN sales.orders ON users.id=orders.user_id;
+
+-- Oracle example
+SELECT * FROM Employees;  -- employees in HR schema
+-- becomes
+SELECT * FROM HR.Employees;
+```
 
 ---
 

--- a/tests/transform_test.py
+++ b/tests/transform_test.py
@@ -3,7 +3,11 @@ from pathlib import Path
 import sys
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
-transform = importlib.import_module("transqlate.sql_transform").transform
+sql_mod = importlib.import_module("transqlate.sql_transform")
+transform = sql_mod.transform
+qualify_mssql = sql_mod.schema_qualify_mssql
+qualify_pg = sql_mod.schema_qualify_postgres
+qualify_oracle = sql_mod.schema_qualify_oracle
 
 
 def test_sqlite_passthrough():
@@ -33,4 +37,25 @@ def test_oracle_limit_and_now():
     sql = 'SELECT `id` FROM t LIMIT 2;'
     expected = 'SELECT "id" FROM t FETCH FIRST 2 ROWS ONLY;'
     assert transform("oracle", sql) == expected
+
+
+def test_mssql_schema_qualification():
+    sql = 'SELECT TOP 5 Product FROM Products ORDER BY Price DESC;'
+    mapping = {"Products": "Sales"}
+    expected = 'SELECT TOP 5 Product FROM Sales.Products ORDER BY Price DESC;'
+    assert qualify_mssql(sql, mapping) == expected
+
+
+def test_postgres_schema_qualification():
+    sql = 'SELECT * FROM items JOIN orders ON items.id=orders.item_id;'
+    mapping = {"items": "shop", "orders": "sales"}
+    expected = 'SELECT * FROM shop.items JOIN sales.orders ON items.id=orders.item_id;'
+    assert qualify_pg(sql, mapping) == expected
+
+
+def test_oracle_schema_qualification():
+    sql = 'SELECT * FROM Products p JOIN Categories c ON p.cat=c.id'
+    mapping = {"PRODUCTS": "SALES", "CATEGORIES": "HR"}
+    expected = 'SELECT * FROM SALES.Products p JOIN HR.Categories c ON p.cat=c.id'
+    assert qualify_oracle(sql, mapping, 'SCOTT') == expected
 


### PR DESCRIPTION
## Summary
- expand schema qualification logic to PostgreSQL and Oracle
- generalize CLI table schema handling and qualification
- store schema info in extractors for PostgreSQL and Oracle
- document examples of automatic schema prefixing
- test qualification for MSSQL, Oracle and PostgreSQL

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c5925b13c83338d084c2bfb499ab1