### PR TITLE
feat: platform-agnostic quantisation & bitsandbytes gating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 utils/
+!src/transqlate/utils/
 dataset/
 __pycache__/
 **/__pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,7 +127,7 @@
 ---
 
 ## What's New in v0.1.4
-**Minor fix - update package dependencies**
+**Portable quantisation gating, CPU-only support, new `--no-quant` flag**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,19 @@ transqlate -q "Which customers made purchases in March?" --db-path path/to/your.
 
 ![Transqlate CLI Demo](assets/cli-demo.gif)
 
+### Hardware & Quantisation
+
+Transqlate automatically selects the best precision for your system. On CUDA GPUs with a compatible `bitsandbytes` installation, the model loads in 4‑bit NF4 quantised mode. Otherwise it falls back to full precision. Use `--no-quant` or set the environment variable `TRANSQLATE_NO_QUANT=1` to disable quantisation explicitly.
+
+| Host type | BnB present & compatible | Expected load mode |
+| --------- | ----------------------- | ------------------ |
+| CUDA GPU (>=7 GB) | ✔ | 4-bit NF4 quant (bnb) |
+| CUDA GPU | ✖ / incompatible | fp16 |
+| Apple M-series (MPS) | n/a | fp16 |
+| CPU, ≥13 GB RAM | (any) | fp32 |
+| CPU, <13 GB RAM | (any) | graceful error suggesting `transqlate-tiny` |
+| Any host | user sets `--no-quant` or `TRANSQLATE_NO_QUANT=1` | quantisation disabled |
+
 #### **CLI Features**
 
 * Interactive natural language to SQL translation

--- a/src/transqlate/Dockerfile
+++ b/src/transqlate/Dockerfile
@@ -3,7 +3,8 @@
 ##############################
 
  # Debian 12 (multi-arch: amd64 & arm64)
-FROM python:3.11.7-slim     
+FROM python:3.11.7-slim
+ARG INSTALL_BNB="false"
 
 WORKDIR /app
 ENV PYTHONUNBUFFERED=1 PYTHONIOENCODING=UTF-8
@@ -24,6 +25,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # ---- Python dependencies ----
 COPY requirements.txt .
+RUN if [ "$INSTALL_BNB" = "false" ]; then \
+        pip install --no-binary :all: --no-deps bitsandbytes || true; \
+    fi
 RUN pip install --no-cache-dir --prefer-binary -r requirements.txt
 
 # ---- Project code & CLI install ----

--- a/src/transqlate/utils/hardware.py
+++ b/src/transqlate/utils/hardware.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+import os
+import torch
+from transformers.integrations.bitsandbytes import (
+    is_bitsandbytes_available,
+    _validate_bnb_multi_backend_availability,
+)
+
+
+def detect_device_and_quant(user_opt_out: bool) -> tuple[dict | str, torch.dtype, bool]:
+    """Detect device and desired quantisation settings.
+
+    Returns
+    -------
+    device_map : dict | str
+        Mapping passed to Transformers ``from_pretrained``.
+    torch_dtype : torch.dtype
+        Precision to load weights with.
+    use_4bit : bool
+        Whether to attempt 4-bit quantisation via bitsandbytes.
+    """
+    if user_opt_out:
+        return "cpu", torch.float32, False
+
+    if torch.cuda.is_available():
+        if is_bitsandbytes_available():
+            try:
+                _validate_bnb_multi_backend_availability()
+                return "auto", torch.bfloat16, True
+            except Exception:
+                pass
+        return "auto", torch.float16, False
+
+    if torch.backends.mps.is_available():
+        return {"": "mps"}, torch.float16, False
+
+    return "cpu", torch.float32, False

--- a/tests/test_quant_gating.py
+++ b/tests/test_quant_gating.py
@@ -1,0 +1,33 @@
+import importlib
+
+def test_cpu_opt_out(monkeypatch):
+    monkeypatch.setenv("TRANSQLATE_NO_QUANT", "1")
+    from transqlate.utils.hardware import detect_device_and_quant
+    dm, dt, q = detect_device_and_quant(True)
+    assert q is False
+
+
+def test_retry_on_bnb_failure(monkeypatch, mocker):
+    import torch
+    mocker.patch(
+        "transqlate.utils.hardware.detect_device_and_quant",
+        return_value=("auto", torch.float16, True),
+    )
+    import transqlate.inference as inf
+
+    class DummyModel:
+        def eval(self):
+            pass
+
+    mock_model = mocker.patch(
+        "transformers.AutoModelForCausalLM.from_pretrained",
+        side_effect=[RuntimeError("bitsandbytes"), DummyModel()],
+    )
+
+    class DummyTok:
+        eos_token = ""
+        pad_token = ""
+
+    mocker.patch("transformers.AutoTokenizer.from_pretrained", return_value=DummyTok())
+    inf.NL2SQLInference(model_dir="dummy")
+    assert mock_model.call_count == 2


### PR DESCRIPTION
## Summary
- add device/quant detection helper
- retry model load if bitsandbytes fails
- expose `--no-quant` CLI flag and show load banner
- make Dockerfile optionally install bitsandbytes
- document hardware requirements and update changelog
- test quantisation gating logic

## Testing
- `pytest -q`
- `ruff check .` *(fails: Found 21 errors)*
- `mypy src/transqlate/utils/hardware.py`

------
https://chatgpt.com/codex/tasks/task_e_68513dc76afc8333a06316750e7d3985