### PR TITLE
Fix bitsandbytes multi-backend check

### DIFF
--- a/src/transqlate/utils/hardware.py
+++ b/src/transqlate/utils/hardware.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 import os
+import logging
 import torch
 from transformers.integrations.bitsandbytes import (
     is_bitsandbytes_available,
     _validate_bnb_multi_backend_availability,
 )
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
 
 
 def detect_device_and_quant(user_opt_out: bool) -> tuple[dict | str, torch.dtype, bool]:
@@ -25,10 +29,10 @@ def detect_device_and_quant(user_opt_out: bool) -> tuple[dict | str, torch.dtype
     if torch.cuda.is_available():
         if is_bitsandbytes_available():
             try:
-                _validate_bnb_multi_backend_availability()
+                _validate_bnb_multi_backend_availability(raise_exception=True)
                 return "auto", torch.bfloat16, True
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("bitsandbytes backend unavailable: %s", exc)
         return "auto", torch.float16, False
 
     if torch.backends.mps.is_available():


### PR DESCRIPTION
## Summary
- log hardware helper operations
- call `_validate_bnb_multi_backend_availability` with the new `raise_exception` parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68515054b8e08333ad299002f6277cf5