### PR TITLE
Improve bitsandbytes detection and error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,8 @@
 - **Model & CLI**
   - SentenceTransformer loading errors are handled gracefully, with user instructions if download fails.
   - Dataset file path issues in training scripts resolved.
-  - Duplicate imports and old citation placeholders removed from finetuning scripts.
+- Duplicate imports and old citation placeholders removed from finetuning scripts.
+- 4-bit mode now only selected when the `bitsandbytes` package is actually installed. Model loading gracefully retries without quantization if package metadata is missing.
 
 ---
 

--- a/src/transqlate/inference.py
+++ b/src/transqlate/inference.py
@@ -23,6 +23,7 @@ from transformers import (
     TextIteratorStreamer,
     BitsAndBytesConfig,
 )
+import importlib.metadata
 
 from transqlate.utils.hardware import detect_device_and_quant
 
@@ -148,6 +149,13 @@ class NL2SQLInference:
                 self.use_4bit = False
             else:
                 raise
+        except importlib.metadata.PackageNotFoundError:
+            model_kwargs.pop("quantization_config", None)
+            self.model = AutoModelForCausalLM.from_pretrained(
+                model_id_str,
+                **model_kwargs,
+            )
+            self.use_4bit = False
         self.model.eval()
 
     # ------------------------------------------------------------------

--- a/src/transqlate/utils/hardware.py
+++ b/src/transqlate/utils/hardware.py
@@ -3,12 +3,23 @@ import os
 import logging
 import torch
 from transformers.integrations.bitsandbytes import (
-    is_bitsandbytes_available,
     _validate_bnb_multi_backend_availability,
 )
+import importlib.metadata
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
+
+
+def _is_bnb_installed() -> bool:
+    """Return True if the bitsandbytes package is installed."""
+    try:
+        importlib.metadata.version("bitsandbytes")
+        return True
+    except importlib.metadata.PackageNotFoundError:
+        return False
+    except Exception:
+        return False
 
 
 def detect_device_and_quant(user_opt_out: bool) -> tuple[dict | str, torch.dtype, bool]:
@@ -27,7 +38,7 @@ def detect_device_and_quant(user_opt_out: bool) -> tuple[dict | str, torch.dtype
         return "cpu", torch.float32, False
 
     if torch.cuda.is_available():
-        if is_bitsandbytes_available():
+        if _is_bnb_installed():
             try:
                 _validate_bnb_multi_backend_availability(raise_exception=True)
                 return "auto", torch.bfloat16, True

--- a/tests/test_quant_gating.py
+++ b/tests/test_quant_gating.py
@@ -1,4 +1,29 @@
 import importlib
+import sys
+import types
+from pathlib import Path
+
+if "torch" not in sys.modules:
+    sys.modules["torch"] = types.SimpleNamespace(float16="fp16", bfloat16="bf16", float32="fp32")
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+tfm = types.ModuleType("transformers")
+tfm.AutoConfig = object
+tfm.PretrainedConfig = object
+tfm.AutoModelForCausalLM = types.SimpleNamespace(from_pretrained=lambda *a, **k: None)
+tfm.AutoTokenizer = types.SimpleNamespace(from_pretrained=lambda *a, **k: None)
+tfm.TextIteratorStreamer = object
+class _BitsAndBytesConfig:
+    def __init__(self, *a, **k):
+        pass
+
+tfm.BitsAndBytesConfig = _BitsAndBytesConfig
+sys.modules.setdefault("transformers", tfm)
+sys.modules.setdefault("transformers.integrations", types.ModuleType("integrations"))
+bnb_mod = types.ModuleType("bitsandbytes")
+bnb_mod._validate_bnb_multi_backend_availability = lambda *a, **k: None
+sys.modules["transformers.integrations.bitsandbytes"] = bnb_mod
+import transqlate.utils.hardware  # ensure module is loadable
 
 def test_cpu_opt_out(monkeypatch):
     monkeypatch.setenv("TRANSQLATE_NO_QUANT", "1")
@@ -31,3 +56,30 @@ def test_retry_on_bnb_failure(monkeypatch, mocker):
     mocker.patch("transformers.AutoTokenizer.from_pretrained", return_value=DummyTok())
     inf.NL2SQLInference(model_dir="dummy")
     assert mock_model.call_count == 2
+
+
+def test_retry_on_pkg_missing(monkeypatch, mocker):
+    import torch
+    mocker.patch(
+        "transqlate.utils.hardware.detect_device_and_quant",
+        return_value=("auto", torch.float16, True),
+    )
+    import transqlate.inference as inf
+
+    class DummyModel:
+        def eval(self):
+            pass
+
+    mock_model = mocker.patch(
+        "transformers.AutoModelForCausalLM.from_pretrained",
+        side_effect=[importlib.metadata.PackageNotFoundError("bitsandbytes"), DummyModel()],
+    )
+
+    class DummyTok:
+        eos_token = ""
+        pad_token = ""
+
+    mocker.patch("transformers.AutoTokenizer.from_pretrained", return_value=DummyTok())
+    obj = inf.NL2SQLInference(model_dir="dummy")
+    assert mock_model.call_count == 2
+    assert obj.use_4bit is False


### PR DESCRIPTION
## Summary
- check for bitsandbytes metadata before attempting 4-bit quant
- handle missing bitsandbytes metadata during model load
- add regression test for PackageNotFoundError retry path
- document the quantisation gating fix

## Testing
- `pytest tests/test_quant_gating.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685170343ef083339e774277f5de2b4d