### PR TITLE
Fix quantization config removal when bitsandbytes missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
   - Dataset file path issues in training scripts resolved.
 - Duplicate imports and old citation placeholders removed from finetuning scripts.
 - 4-bit mode now only selected when the `bitsandbytes` package is actually installed. Model loading gracefully retries without quantization if package metadata is missing.
+- 4-bit models shipped with a `quantization_config` field no longer fail to load when `bitsandbytes` is unavailable.
 
 ---
 

--- a/src/transqlate/inference.py
+++ b/src/transqlate/inference.py
@@ -151,6 +151,10 @@ class NL2SQLInference:
                 raise
         except importlib.metadata.PackageNotFoundError:
             model_kwargs.pop("quantization_config", None)
+            if hasattr(config, "quantization_config"):
+                delattr(config, "quantization_config")
+                config = AutoConfig.from_dict(config.to_dict())
+                model_kwargs["config"] = config
             self.model = AutoModelForCausalLM.from_pretrained(
                 model_id_str,
                 **model_kwargs,


### PR DESCRIPTION
## Summary
- drop `quantization_config` from config when bitsandbytes is unavailable
- retry load with updated config and disable 4-bit
- test config cleanup logic
- document fix in changelog

## Testing
- `pytest -q tests/test_quant_gating.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_685177c912f883339496ed492c88bc72