### PR TITLE
Fix config restoration logic and update test mocks

### DIFF
--- a/src/transqlate/cli/cli.py
+++ b/src/transqlate/cli/cli.py
@@ -21,7 +21,10 @@ import logging
 import re
 import traceback
 import shlex
-import torch
+try:
+    import torch
+except Exception:  # pragma: no cover - optional dependency
+    torch = None
 from getpass import getpass
 from typing import List, Optional, Tuple, Dict
 from dataclasses import dataclass

--- a/src/transqlate/inference.py
+++ b/src/transqlate/inference.py
@@ -97,7 +97,7 @@ class NL2SQLInference:
             config = PretrainedConfig()
         if hasattr(config, "quantization_config") and config.quantization_config is None:
             delattr(config, "quantization_config")
-            config = AutoConfig.from_dict(config.to_dict())
+            config = config.__class__.from_dict(config.to_dict())
 
         self.tokenizer = AutoTokenizer.from_pretrained(model_path, use_fast=True)
         # Ensure clean decoding
@@ -153,7 +153,7 @@ class NL2SQLInference:
             model_kwargs.pop("quantization_config", None)
             if hasattr(config, "quantization_config"):
                 delattr(config, "quantization_config")
-                config = AutoConfig.from_dict(config.to_dict())
+                config = config.__class__.from_dict(config.to_dict())
                 model_kwargs["config"] = config
             self.model = AutoModelForCausalLM.from_pretrained(
                 model_id_str,

--- a/tests/test_quant_gating.py
+++ b/tests/test_quant_gating.py
@@ -108,12 +108,15 @@ def test_retry_with_quant_attr(monkeypatch, mocker):
         def to_dict(self):
             return {}
 
+        @classmethod
+        def from_dict(cls, *a, **k):
+            return cls()
+
     monkeypatch.setattr(
         tfm,
         "AutoConfig",
         types.SimpleNamespace(
             from_pretrained=lambda *a, **k: DummyConfig(),
-            from_dict=lambda *a, **k: DummyConfig(),
         ),
     )
 


### PR DESCRIPTION
## Summary
- recreate model configs using `config.__class__.from_dict` instead of `AutoConfig.from_dict`
- fall back to a dummy torch module when torch isn't installed so the CLI can be imported in tests
- update quant gating test to patch the dummy config class

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68517e699b78833388efd0301a3c5f84