### PR TITLE
Remove fallbacks for non‑CUDA installs

### DIFF
--- a/src/transqlate/inference.py
+++ b/src/transqlate/inference.py
@@ -23,7 +23,6 @@ from transformers import (
     TextIteratorStreamer,
     BitsAndBytesConfig,
 )
-import importlib.metadata
 
 from transqlate.utils.hardware import detect_device_and_quant
 
@@ -112,58 +111,21 @@ class NL2SQLInference:
         if quant_config is not None:
             model_kwargs["quantization_config"] = quant_config
 
-        try:
-            with warnings.catch_warnings():
-                warnings.filterwarnings(
-                    "ignore",
-                    message=(
-                        "You passed `quantization_config` or equivalent parameters to "
-                        "`from_pretrained` but the model you're loading already has a "
-                        "`quantization_config` attribute. The `quantization_config` "
-                        "from the model will be used."
-                    ),
-                    category=UserWarning,
-                )
-                self.model = AutoModelForCausalLM.from_pretrained(
-                    model_id_str,
-                    **model_kwargs,
-                )
-        except RuntimeError as e:
-            if "bitsandbytes" in str(e).lower():
-                model_kwargs.pop("quantization_config", None)
-                if hasattr(config, "quantization_config"):
-                    delattr(config, "quantization_config")
-                    config = config.__class__.from_dict(config.to_dict())
-                    model_kwargs["config"] = config
-                with warnings.catch_warnings():
-                    warnings.filterwarnings(
-                        "ignore",
-                        message=(
-                            "You passed `quantization_config` or equivalent parameters to "
-                            "`from_pretrained` but the model you're loading already has a "
-                            "`quantization_config` attribute. The `quantization_config` "
-                            "from the model will be used."
-                        ),
-                        category=UserWarning,
-                    )
-                    self.model = AutoModelForCausalLM.from_pretrained(
-                        model_id_str,
-                        **model_kwargs,
-                    )
-                self.use_4bit = False
-            else:
-                raise
-        except importlib.metadata.PackageNotFoundError:
-            model_kwargs.pop("quantization_config", None)
-            if hasattr(config, "quantization_config"):
-                delattr(config, "quantization_config")
-                config = config.__class__.from_dict(config.to_dict())
-                model_kwargs["config"] = config
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=(
+                    "You passed `quantization_config` or equivalent parameters to "
+                    "`from_pretrained` but the model you're loading already has a "
+                    "`quantization_config` attribute. The `quantization_config` "
+                    "from the model will be used."
+                ),
+                category=UserWarning,
+            )
             self.model = AutoModelForCausalLM.from_pretrained(
                 model_id_str,
                 **model_kwargs,
             )
-            self.use_4bit = False
         self.model.eval()
 
     # ------------------------------------------------------------------

--- a/src/transqlate/utils/hardware.py
+++ b/src/transqlate/utils/hardware.py
@@ -37,16 +37,11 @@ def detect_device_and_quant(user_opt_out: bool) -> tuple[dict | str, torch.dtype
     if user_opt_out:
         return "cpu", torch.float32, False
 
-    if torch.cuda.is_available():
-        if _is_bnb_installed():
-            try:
-                _validate_bnb_multi_backend_availability(raise_exception=True)
-                return "auto", torch.bfloat16, True
-            except Exception as exc:
-                logger.debug("bitsandbytes backend unavailable: %s", exc)
-        return "auto", torch.float16, False
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA device required for 4-bit weights")
 
-    if torch.backends.mps.is_available():
-        return {"": "mps"}, torch.float16, False
+    if not _is_bnb_installed():
+        raise RuntimeError("bitsandbytes is required for 4-bit weights")
 
-    return "cpu", torch.float32, False
+    _validate_bnb_multi_backend_availability(raise_exception=True)
+    return "auto", torch.bfloat16, True


### PR DESCRIPTION
## Summary
- enforce CUDA+bitsandbytes requirement in `detect_device_and_quant`
- stop retrying model load without quantisation
- restore friendly GPU error message in CLI
- update tests for new behaviour

## Testing
- `pip install -r requirements.txt`
- `pip install pytest-mock`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852c5764bb483339f6b3b36b4ae24ce